### PR TITLE
Allow option 'plugins' to be a function in HappyLoader

### DIFF
--- a/lib/HappyLoader.js
+++ b/lib/HappyLoader.js
@@ -10,6 +10,10 @@ function HappyLoader(sourceCode, sourceMap) {
   assert(callback, "HappyPack only works when asynchronous loaders are allowed!");
 
   this.cacheable();
+  
+  if (typeof this.options.plugins === 'function') {
+      this.options.plugins = this.options.plugins();
+  }
 
   if (!this.options.plugins) {
     return callback(null, sourceCode, sourceMap);


### PR DESCRIPTION
Hello,
I made it available to make 'plugins' in HappyLoader a function.

It may be useful for integration with webpack >= 2.1.0-beta.23 which has a new mechanism of loading options with LoaderOptionsPlugin

If we define LoaderOptionsPlugin as:
`new webpack.LoaderOptionsPlugin({
        options: {
            plugins: function () {return plugins;}
        },
    }),
`
`plugins` will be available in HappyLoader, and HappyPack won't be broken. 